### PR TITLE
Fix failure of pulumi preview with AWS_PROFILE

### DIFF
--- a/eks/Pulumi.yaml
+++ b/eks/Pulumi.yaml
@@ -7,7 +7,7 @@ template:
     aws:region:
       description: The AWS region to deploy into (`us-east-1`, `us-west-2`, `eu-west-1`)
       default: "us-west-2"
-    instanceType: 
+    instanceType:
       description: The instance type to use for the cluster's nodes
       default: "t2.medium"
     desiredCapacity:
@@ -22,6 +22,3 @@ template:
     storageClass:
       description: Create a storage class for the given volume type and make it the cluster's default StorageClass
       default: "gp2"
-    deployDashboard:
-      description: Whether or not to deploy the Kubernetes dashboard to the cluster
-      default: "true"

--- a/eks/index.ts
+++ b/eks/index.ts
@@ -10,7 +10,6 @@ const desiredCapacity = config.getNumber("desiredCapacity");
 const minSize = config.getNumber("minSize");
 const maxSize = config.getNumber("maxSize");
 const storageClass = config.get("storageClass") as eks.EBSVolumeType;
-const deployDashboard = config.getBoolean("deployDashboard");
 
 // Create a VPC for our cluster.
 const vpc = new awsx.ec2.Vpc("eksvpc", {
@@ -26,7 +25,7 @@ const cluster = new eks.Cluster("cluster", {
     minSize: minSize,
     maxSize: maxSize,
     storageClasses: storageClass,
-    deployDashboard: deployDashboard,
+    providerCredentialOpts: {}
 });
 
 // Export the cluster's kubeconfig.


### PR DESCRIPTION
When I do `pulumi new https://github.com/pulumi/apps/eks` and then `AWS_PROFILE=devsandbox pulumi preview` in the generated app, it fails with:

```
    error: Running program '/Users/anton/apps/eks' failed with an unhandled exception:
    Error: providerCredentialOpts and AWS_PROFILE must be set together
        at new Cluster (/Users/anton/apps/eks/node_modules/@pulumi/cluster.ts:1385:19)
        at Object.<anonymous> (/Users/anton/apps/eks/index.ts:21:17)
        at Module._compile (internal/modules/cjs/loader.js:1137:30)
        at Module.m._compile (/Users/anton/apps/eks/node_modules/ts-node/src/index.ts:439:23)
        at Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
        at Object.require.extensions.<computed> [as .ts] (/Users/anton/apps/eks/node_modules/ts-node/src/index.ts:442:12)
        at Module.load (internal/modules/cjs/loader.js:985:32)
        at Function.Module._load (internal/modules/cjs/loader.js:878:14)
        at Module.require (internal/modules/cjs/loader.js:1025:19)
        at require (internal/modules/cjs/helpers.js:72:18)
```

Adding empty `providerCredentialOpts` fixes it for me. But this sounds fishy.

I have created `devsandbox` profile via `aws configure sso`.

IN addition to that, the dashboard arg is triggering a deprecation warning.

```
pulumi version
v2.25.0

pulumi plugin ls
NAME        KIND      VERSION  SIZE    INSTALLED       LAST USED
aws         resource  3.38.1   253 MB  29 minutes ago  29 minutes ago
docker      resource  2.10.0   39 MB   29 minutes ago  29 minutes ago
kubernetes  resource  2.9.1    71 MB   29 minutes ago  12 minutes ago

aws --version
aws-cli/2.1.29 Python/3.8.8 Darwin/19.6.0 source/x86_64 prompt/off
```

Let me test if the change breaks other auth methods.