### PR TITLE
Fix subnet config

### DIFF
--- a/eks/index.ts
+++ b/eks/index.ts
@@ -13,9 +13,7 @@ const storageClass = config.get("storageClass") as eks.EBSVolumeType;
 const deployDashboard = config.getBoolean("deployDashboard");
 
 // Create a VPC for our cluster.
-const vpc = new awsx.ec2.Vpc("eksvpc", {
-    subnetSpecs: [{ type: awsx.ec2.SubnetType.Public }],
-});
+const vpc = new awsx.ec2.Vpc("eksvpc", {});
 
 // Create an EKS cluster with the given configuration.
 const cluster = new eks.Cluster("cluster", {


### PR DESCRIPTION
The existing example fails with
error: Error: If NAT Gateway strategy is 'OnePerAz' or 'Single', both private and public subnets must be declared. The private subnet creates the need for a NAT Gateway, and the public subnet is required to host the NAT Gateway resource.

It's probably easiest to just use the default subnet config, which will create a private and public subnets AFAIK